### PR TITLE
Rewrite DB Connection Management 

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -3,8 +3,6 @@
 # various functions and objects for BIAD
 #----------------------------------------------------------------------------------------------------
 #----------------------------------------------------------------------------------------------------
-dbname <<- 'BIAD'
-source("https://raw.githubusercontent.com/BIADwiki/BIADwiki/main/R/functions.database.connect.R")
 source("https://raw.githubusercontent.com/AdrianTimpson/snippets/main/R/functions.R")
 #----------------------------------------------------------------------------------------------------
 run.server.searcher <- function(table.name, primary.value){

--- a/R/functions.database.connect.R
+++ b/R/functions.database.connect.R
@@ -13,7 +13,7 @@ run.server.query <- function(sql.command,db.credentials=NULL, hostuser=NULL, hos
         "conn <- init.conn()", ##credendtial will be passed through env variable so they don't need to be written anywhere
 		"query <- query.database(conn, sql.command)",
 		"save(query, file='tmp.RData')",
-		"DBI::dbDisconnect(conn)",
+		"DBI::dbDisconnect(conn)"
 		)
 	writeLines(text,con= 'server.script.R')
 
@@ -43,7 +43,6 @@ run.server.query.inner <- function(db.credentials=NULL, hostuser=NULL, hostname=
         }
     }
 
-    tmp.path <- tempfile(pattern = "tmpdir")
     if(is.na(Sys.getenv("BIAD_DB_USER")) || is.null(Sys.getenv("BIAD_DB_USER")) || is.null(Sys.getenv("BIAD_DB_USER"))){
         error("as probably only you adrian and I are using this ssh feature i won't do fancy test, but you need to put usernames and passwords in environment variable (via ~/.Renviron or export VAR=dsadsa")
     }
@@ -53,6 +52,7 @@ run.server.query.inner <- function(db.credentials=NULL, hostuser=NULL, hostname=
                        "BIAD_DB_HOST=","\"127.0.0.1\"")
 
 	# create bash commands to be run on server
+    tmp.path <- tempfile(pattern = "tmpdir")
 	commands <- c(
 		paste("cd",tmp.path),
 		paste(env_vars,"/Library/Frameworks/R.framework/Resources/bin/R CMD BATCH --no-save server.script.R tmp.Rout"),

--- a/R/functions.database.connect.R
+++ b/R/functions.database.connect.R
@@ -54,7 +54,7 @@ run.server.query.inner <- function(user, password, hostuser, hostname, pempath){
 
 return(query)}
 #--------------------------------------------------------------------------------------------------
-query.database.inner <- function(user, password, dbname, sql.command){
+query.database.inner <- function(user, password, host, port, dbname, sql.command){
 	require(RMySQL)
 	drv <- dbDriver("MySQL")
 
@@ -63,7 +63,7 @@ query.database.inner <- function(user, password, dbname, sql.command){
 	for(con in cons)dbDisconnect(con)
 
 	# connect locally to the database
-	con <- dbConnect(drv, user=user, pass=password, dbname=dbname, host = "127.0.0.1", port=3306)
+	con <- dbConnect(drv, user=user, pass=password, dbname=dbname, host = host, port = port)
 	dbSendStatement(con,"SET NAMES 'utf8'")
 
 	# query the database and tidy
@@ -76,8 +76,9 @@ query.database.inner <- function(user, password, dbname, sql.command){
 	for(con in cons)dbDisconnect(con)
 return(query)}
 #--------------------------------------------------------------------------------------------------
-query.database <- function(user, password, dbname, sql.command){
-	query <- suppressWarnings(query.database.inner(user, password, dbname, sql.command))
+query.database <- function(user, password, host, port, dbname, sql.command){
+
+	query <- query.database.inner(user, password, host, port, dbname, sql.command)
 return(query)}
 #--------------------------------------------------------------------------------------------------
 encoder <- function(df){

--- a/R/functions.database.connect.R
+++ b/R/functions.database.connect.R
@@ -224,3 +224,5 @@ msp <- function(password) {
     maskp <- strsplit(password, "")[[1]]
     paste0(maskp[1], paste0(rep("*", length(maskp) - 2), collapse = ""), maskp[length(maskp)])
 }
+
+disconnect <- function(drv="MySQL") sapply(DBI::dbListConnections(DBI::dbDriver(drv)),dbDisconnect)

--- a/R/functions.database.connect.R
+++ b/R/functions.database.connect.R
@@ -181,35 +181,32 @@ init.conn <- function(db.credentials=NULL){
             BIAD_DB_PORT=as.numeric(Sys.getenv("BIAD_DB_PORT"))
         )
     }
-    if(any(sapply(db.credentials,is.na)))warning("missing: ",names(db.credentials)[sapply(db.credentials,is.na)],", you may want to check your ~/.Renviron file and reload R, or manually provide db.credentials as a list to init.conn")
-        if (all(sapply(db.credentials, function(cred) is.null(cred) || is.na(cred) || cred == ""))) {
-            if (exists("user", envir = .GlobalEnv) && exists("pass", envir = .GlobalEnv)) {
-                warning("It seems that you are still using credentials set in .Rprofile; we will slowly move to using environment variables that you will set in your .Renviron or you .bashrc.\n",
-                        ".Renviron should be like:\n",
-                        "  BIAD_DB_USER=your_username\n",
-                        "  BIAD_DB_PASS=your_password\n",
-                        "  BIAD_DB_HOST=127.0.0.1 \n",
-                        "  BIAD_DB_PORT=3306 #or something different if you specified a differentport\n",
-                        "or: export BIAD_DB_XXX=XXX if using .bashrc")
-                db.credentials$BIAD_DB_USER <- get("user", envir = .GlobalEnv)
-                db.credentials$BIAD_DB_PASS <- get("pass", envir = .GlobalEnv)
-                db.credentials$BIAD_DB_HOST <- "127.0.0.1"
-                db.credentials$BIAD_DB_PORT <- 3306
-            } 
+    if (all(sapply(db.credentials, function(cred) is.null(cred) || is.na(cred) || cred == ""))) {
+        if (exists("user", envir = .GlobalEnv) && exists("password", envir = .GlobalEnv)) {
+            warning("It seems that you are still using credentials set in .Rprofile; we will slowly move to using environment variables that you will set in your ~/.Renviron or you ~/.bashrc.\n\r",
+                    "Your ~/.Renviron should be like:\n",
+                    "\t BIAD_DB_USER=\"your username\"\n",
+                    "\t BIAD_DB_PASS=\"your password\"\n",
+                    "\t BIAD_DB_HOST=127.0.0.1 \n",
+                    "\t BIAD_DB_PORT=3306 #or something different if you specified a different port\n",
+                    "  or add:  export BIAD_DB_XXX=XXX to your .bashrc")
+            db.credentials$BIAD_DB_USER <- get("user", envir = .GlobalEnv)
+            db.credentials$BIAD_DB_PASS <- get("password", envir = .GlobalEnv)
+            db.credentials$BIAD_DB_HOST <- "127.0.0.1"
+            db.credentials$BIAD_DB_PORT <- 3307
+        } 
     }
-    missing_vars <- names(db.credentials)[sapply(db.credentials, function(x) is.null(x) || identical(x, "NA"))]
-    if (length(missing_vars) > 0) {
-        warning("Missing: ", paste(missing_vars, collapse = ", "), 
-                ". You may want to check your ~/.Renviron file and reload R, or manually provide db.credentials as a list to init.conn."
-        )
-    }
+    missing_vars <- names(db.credentials)[sapply(db.credentials, function(x) is.null(x) || is.na(x) || x == "")]
+    if (length(missing_vars) > 0) 
+        warning("Missing: ", paste(missing_vars, collapse = ", "), ". You may want to check your ~/.Renviron file and reload R, or manually provide db.credentials as a list to init.conn.")
+    
     conn <-  tryCatch(
             DBI::dbConnect(drv=DBI::dbDriver("MySQL"), user=db.credentials$BIAD_DB_USER, pass=db.credentials$BIAD_DB_PASS, dbname="biad", host = db.credentials$BIAD_DB_HOST, port=db.credentials$BIAD_DB_PORT) ,
         error=function(e){
             message("Couldn't initialise connection with the database, dbConnect returned error: ", e)
             message("Check your db.credentials below:")
             na <- sapply(names(db.credentials),function(nc)message(nc,": ", ifelse(nc=="password",msp(db.credentials[[nc]]),db.credentials[[nc]])))
-            message("Note: you can only connect to the dataset through ssh ; check aslo that this is done (cf:https://biadwiki.org/en/Connect)")
+            message("Note: you can only connect to the dataset through ssh ; so you may want to check you're ssh tunel (or any plugin you may use to do so) is working (cf:https://biadwiki.org/en/Connect)")
             stop("DBConnection fail")
     })
     return(conn)	

--- a/R/functions.database.connect.R
+++ b/R/functions.database.connect.R
@@ -43,7 +43,7 @@ run.server.query.inner <- function(db.credentials=NULL, hostuser=NULL, hostname=
         }
     }
 
-	tmp.path <- paste("tmp/tmp",runif(1),sep='')
+    tmp.path <- tempfile(pattern = "tmpdir")
     if(is.na(Sys.getenv("BIAD_DB_USER")) || is.null(Sys.getenv("BIAD_DB_USER")) || is.null(Sys.getenv("BIAD_DB_USER"))){
         error("as probably only you adrian and I are using this ssh feature i won't do fancy test, but you need to put usernames and passwords in environment variable (via ~/.Renviron or export VAR=dsadsa")
     }
@@ -82,7 +82,7 @@ run.server.query.inner <- function(db.credentials=NULL, hostuser=NULL, hostname=
         na <- sapply( readLines("tmp.Rout"),function(i)cat(i,"\n"))
 		warning('sql command failed')
 		}
-    #ssh::ssh_exec_wait(session, command = paste("rm -r",tmp.path))
+    ssh::ssh_exec_wait(session, command = paste("rm -r",tmp.path))
 	ssh::ssh_disconnect(session)
 return(query)}
 


### PR DESCRIPTION
This branch does a few things, all mainly related to connection and interaction with the database.

1. Fixes a few issues (connections problem if `wrapper()` and `fnc()` ;  when used locally  different port where used -- minor)
2. Make some functions slighlty quickier by avoiding opening and closing db connection before and after each query (makeing almost useless now to send quieries via ssh)
3.  Make the code a bit (but just a bit)  safer more robust, by handling credentials through environment variable. 

## New methods and functions for remote interactions

### Function `init.conn()`
In this branch connections are handled by the function `init.conn()`. This return a connection handler that can be used by all the other functions. The function `query.database`, who send commands and return results as dataframe, is now calling `init.conn()` if no connector has been passed along. In this case, the connector obtained is assigned to `conn`  at the `.GlobalEnv` level ; and is thus available  everywhere in the project.
Credential can be manually passed to `init.conn()` via the parameter `db.credentials`. This should be a list of the form:

```R
db.credentials <- list(
    BIAD_DB_USER='dbuser´,
    BIAD_DB_PASS='dpass',
    BIAD_DB_HOST='dbhost',
    BIAD_DB_PORT=1235
)
````

If no credentials are passed to init.conn() it will look for environmental variable (cf below) ; which are system wide;  via `Sys.getenv()`. 
This allow to avoid having objects in the `.Rprofile` that are hanging around and may be overwritten without the user's knowledge. There are a lot of [other options](https://blog.revolutionanalytics.com/2015/11/how-to-store-and-use-authentication-details-with-r.html) to handle credentials ; but so far that was what looked to me like the best one. Open to discussion (and more below)!

In term of speed;  i did a few benchmark in and out of the lab, using the very costly `search` function (due to the tree-like/recursive nature of the search). Results (below) show that by keeping the connection open, the difference between interacting remotely with the database vs sending a script to run the command on the server is small. In contrast, having everyone/anyone able to ssh to the server is something that, I think,  _will have to_ be remove at some point. Open to discussion here too ; but I think that this is a good tradeoff in term of securing and speed, getting us closer to an 'api-like' project.

```R
 currentres=run.server.searcher(table.name = 'Sites', primary.value = 'S10050')
 microbenchmark::microbenchmark(run.server.searcher(table.name = 'Sites', primary.value = 'S10050'),times=5)
 # --- at the lab:
 #Unit: seconds
 #                                                                expr      min       lq     mean   median       uq
 # run.server.searcher(table.name = "Sites", primary.value = "S10050") 2.323519 2.333059 2.408235 2.359926 2.496402
 #      max neval
 # 2.528267     5
 # --- outside the lab:
 #Unit: seconds
 #                                                                expr      min       lq     mean   median       uq
 # run.server.searcher(table.name = "Sites", primary.value = "S10050") 2.574199 2.777513 3.008144 2.852191 3.120371
 #      max neval
 # 3.716444     5
 
 conn <- init.conn(db.credential=list(BIAD_DB_USER="simon carrignon",BIAD_DB_PASS="simon arrignon",BIAD_DB_HOST="127.0.0.1",BIAD_DB_PORT=3307))
 remoteres=run.searcher(table.name = 'Sites', primary.value = 'S10050', conn = conn )
 microbenchmark::microbenchmark(run.searcher(table.name = 'Sites', primary.value = 'S10050',conn = conn),times=5)
 # --- at the lab:
 #Unit: seconds
 #                                                         expr      min       lq     mean   median       uq      max
 # run.searcher(table.name = "Sites", primary.value = "S10050") 3.648775 3.700076 4.016982 3.966496 4.340351 4.429214
 # neval
 #     5
 # --- outside the lab:
 #Unit: seconds
 #                                                                                                                          expr
 # run.searcher(table.name = "Sites", primary.value = "S10050",      user = user, password = password, host = host, port = ort)
 #      min       lq     mean   median       uq      max neval
 # 8.987218 9.038348 10.42252 9.338684 12.24129 12.50706     5

``` 


### Credentials passed and saved via Environment Variables : 

[Environment variables](https://en.wikipedia.org/wiki/Environment_variable) are set at the OS level. They allow to use the credentials outside of R (in python, in your fav shell, ssh,etc..). As they are OS-wide, and to avoid they overwrite other OS variables, I propose to use these new names:

```bash
BIAD_DB_USER="your username"
BIAD_DB_PASS="your password"
BIAD_DB_HOST=127.0.0.1
BIAD_DB_PORT=3306 #or something different if you specified a different port\n",
```

The same is done for ssh related credentials:

```
 BIAD_SSH_PEM="/path/to/file.pem"
 BIAD_SSH_USER="biad"
 BIAD_SSH_HOST="macelab-server.biochem.ucl.ac.uk"
```

bash users can thus add them in their `~/.bashrc` but R can also automatically load environment variable using `~/.Rprofile`

A `~/.Rprofile` will look like that:

```R
BIAD_DB_USER="your username"
BIAD_DB_PASS="your password"
BIAD_DB_HOST=127.0.0.1
BIAD_DB_PORT=3306 #or something different if you specified a different port\n",
BIAD_SSH_PEM="/path/to/file.pem"
BIAD_SSH_USER="biad"
BIAD_SSH_HOST="macelab-server.biochem.ucl.ac.uk"
```

Whereas `.bashrc` will have: 

```bash
export BIAD_DB_USER="your username"
export BIAD_DB_PASS="your password"
export BIAD_DB_HOST=127.0.0.1
export BIAD_DB_PORT=3306 #or something different if you specified a different port\n",
export BIAD_SSH_PEM="/path/to/file.pem"
export BIAD_SSH_USER="biad"
export BIAD_SSH_HOST="macelab-server.biochem.ucl.ac.uk"
```
With the envars set up in your `.bashrc`  (or any config fav for your shell ) you can connect to the database without R like this:

```bash
  mysql -u "${BIAD_DB_USER}" -P $BIAD_DB_PORT -h $BIAD_DB_HOST -p"$BIAD_DB_PASS" biad
````

or use ssh via: 
```bash
ssh -i $BIAD_SSH_PEM $BIAD_SSH_USER@$BIAD_SSH_HOST
```
looks barbarian but trust me, it's nice!

One direct advantage is that it allows to send ssh commands in a slightly easier and safer way:  we don't have to copy the credentials in the R script, we can pass them directly to the shell. No need to write credential in the script. 

I also drafted function that leverage this to do only ssh system call (ie not run by R but by the operating system) ; instead of the `ssh` package. That illustrate well the usefulness of envars:

```R
run.server.query.inner.alt <- function(scriptname){ 
	commands <- c(
		paste("cd",tmp.path),
		paste("/Library/Frameworks/R.framework/Resources/bin/R CMD BATCH --no-save",scriptname," > tmp.Rout"),
		"cd .."
		)
    tmp.path <- tempfile(pattern = "tmpdir")
    linkcred="-i ${BIAD_SSH_PEM}"
    host="${BIAD_SSH_USER}@${BIAD_SSH_HOST}" #we rely again on the ENV var
    system(paste("ssh", linkcred, host, shQuote(paste("mkdir -p", tmp.path))))
    sourcefold=here::here("R") #link to the source files
    filestosend <- paste(scriptname,file.path(sourcefold,"function*.R")) #send the script and all source file
    system(paste("scp", linkcred,filestosend, paste0(host,":",tmp.path,"/")))
    res <- c("tmp.RData","tmp.Rout")
    res <- sapply(res,function(fn)paste(tmp.path,fn,sep="/"))
    system(paste("ssh", linkcred, host, shQuote(paste(commands, collapse = "; ")) ,collapse=" "))
    dl  <- sapply(res,function(fn)system(paste("scp", linkcred, paste0(host,":",fn),".")))
    if(file.exists("tmp.RData")){
        load('tmp.RData')
        unlink(c('tmp.RData','tmp.Rout'))
    }
    else{
        query <- NULL
        na <- sapply(readLines("tmp.Rout"),function(i)cat(i,"\n"))
        unlink('tmp.Rout')
        warning('sql command failed')
    }
}
````

The function (not used yet in this branch, but left as a draft/illustration) doesn't need to know _anything_ about the credentials, except the names of the variable. The value are only dealt with  at the OS level.

**NOTE:** The function `init.conn()` is still looking for `.GlobalEnv` variables to initialise the connection if it doesn't find any envar or the list `db.credentials` hasn't been given ; so in theory it's still possible to login with `.Rprofile` credentials. 

## Other minor changes

### Sending script via SSH:
`run.server.query.inner`/`run.server.query.` and `run.server.searcher` have been adapted to account for the new credentials. 
A few minor change have also been introduce ; the use of `tempfile(pattern = "tmpdir")` is introduced to generate temp directory where files are stored and the output of the script run is shown to user if no data is returned. 
The  core files providing all functions (`functions.R` and `functions.database.connection.R`) are not downloaded from github anymore ; but sent from the computer doing the request. This should disappear on the long run, when the project become a package, as the package will be installed on BIAD and thus there will be no need of sending anything ; simply loading the package will do.

### Divers
- I may have changed a few minor things here and there that are not listed here, but they shouldn't impact anything.
- Call to external library (mainly `DBI` and `ssh`) are indicated using `library_name::function()` convention . Will help avoiding some confusion
- The branch tries to use  `init.comm()` and the `conn` and `db.credentials` arguments in a consistent way within all the functions that potentially need to query the database (via the `query.database` function). This is making the whole thing a bit more robust to arguments/variable overwriting (for example in `wrapper` function).  
- The `query.inner.database` has been deleted, warnings are now _only_ suppressed at the level of the `DBI::dbSendStatment` calls in `query.database`.
-  A few `tryCatch`s have been added, to help users handling connections errors.
-  The branch starts to implement Roxygen comments. This will allow to automatically generate documentation if/when the repo becomes a package. They can look like that (for a very extended version):

```R
#--------------------------------------------------------------------------------------------------
#' Initialize Database Connection
#'
#' Establishes a connection to the BIAD database using provided credentials or environment-sourced credentials.
#' If no credentials are supplied, the function attempts to retrieve required details from environment variables.
#'
#' @param db.credentials A list containing database connection details, specifically: 
#'   - `BIAD_DB_USER`: The database username.
#'   - `BIAD_DB_PASS`: The database password.
#'   - `BIAD_DB_HOST`: The host address of the database.
#'   - `BIAD_DB_PORT`: The port number for the database connection. 
#' If not defined, these values are fetched from the environment variables set in your `~/.Renviron` 
#' or in your `~/.bashrc` 
#'
#' @return A DBI connection object to the MySQL database.
#'
#' @seealso \code{\link[DBI]{dbConnect}} for more details on database connections.
#'
#' @examples
#' \dontrun{
#' # Connect using environment variables:
#' conn <- init.conn()
#'
#' # Connect using explicitly provided credentials:
#' db.credentials <- list(
#'   BIAD_DB_USER = "my_user",
#'   BIAD_DB_PASS = "my_password",
#'   BIAD_DB_HOST = "localhost",
#'   BIAD_DB_PORT = 3306
#' )
#' conn <- init.conn(db.credentials)
#' }
#'
#' @export
````

(and we obviously keep the #-------- separators)

## Ending Notes

That was just a few things that appears while I was playing with the code to explore the Sites table. It's far from perfect or good, so need to be reviewed quickly. Not all propositions have to be accepted (I should have split that in multiple branches/patches but with these connections things everything is so interconnect that it grew a bit organically).  

I also have no preference regarding formatting and variable naming/indentation. I thing at some point will be worth having a [pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) and [guideline](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors) to be sure we all do the things the same way.

